### PR TITLE
refactor: add hashing abstraction

### DIFF
--- a/phpunit.ci-build.xml
+++ b/phpunit.ci-build.xml
@@ -14,6 +14,7 @@
     failOnWarning="false">
     <testsuites>
         <testsuite name="default">
+            <directory>tests/unit/Http</directory>
             <directory>tests/unit/Infrastructure</directory>
             <directory>tests/unit/Services</directory>
             <file>tests/unit/AppConfigTest.php</file>

--- a/src/Http/RequestProcessors/AbstractTenantBasedRequestProcessor.php
+++ b/src/Http/RequestProcessors/AbstractTenantBasedRequestProcessor.php
@@ -4,35 +4,17 @@ declare(strict_types=1);
 
 namespace EricFortmeyer\ActivityLog\Http\RequestProcessors;
 
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Phpolar\Phpolar\Auth\AbstractRestrictedAccessRequestProcessor;
-use SensitiveParameter;
-
-use function sodium_bin2hex;
-use function sodium_crypto_generichash;
-
-use const SODIUM_CRYPTO_GENERICHASH_BYTES_MIN;
 
 abstract class AbstractTenantBasedRequestProcessor extends AbstractRestrictedAccessRequestProcessor
 {
     public function __construct(
-        #[SensitiveParameter]
-        private readonly string $hashingKey,
+        private Hasher $hasher,
     ) {}
 
     public function getTenantId(): string
     {
-        return sodium_bin2hex(
-            $this->hashingKey !== ""
-                ?
-                sodium_crypto_generichash(
-                    message: $this->user->nickname,
-                    key: $this->hashingKey,
-                    length: SODIUM_CRYPTO_GENERICHASH_BYTES_MIN,
-                ) :
-                sodium_crypto_generichash(
-                    message: $this->user->nickname,
-                    length: SODIUM_CRYPTO_GENERICHASH_BYTES_MIN,
-                )
-        );
+        return $this->hasher->hash($this->user->nickname);
     }
 }

--- a/src/Http/RequestProcessors/DeleteTimeEntry.php
+++ b/src/Http/RequestProcessors/DeleteTimeEntry.php
@@ -16,6 +16,7 @@ use Phpolar\Storage\NotFound;
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\{NotFoundContext, TimeEntriesContext};
 use EricFortmeyer\ActivityLog\Services\{TimeEntryService, RemarksForMonthService};
 use EricFortmeyer\ActivityLog\{MonthFilters, RemarksForMonth};
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use SensitiveParameter;
 
 /**
@@ -29,10 +30,9 @@ final class DeleteTimeEntry extends AbstractTenantBasedRequestProcessor
         private readonly TimeEntryService $timeEntryService,
         private readonly RemarksForMonthService $remarksForMonthService,
         private readonly TemplateEngine $templateEngine,
-        #[SensitiveParameter]
-        readonly string $hashingKey = "",
+        readonly Hasher $hasher,
     ) {
-        parent::__construct(hashingKey: $hashingKey);
+        parent::__construct($hasher);
     }
 
     #[Authorize]

--- a/src/Http/RequestProcessors/EmailReportForMonth.php
+++ b/src/Http/RequestProcessors/EmailReportForMonth.php
@@ -18,6 +18,7 @@ use EricFortmeyer\ActivityLog\Services\{
     RemarksForMonthService,
     CreditHoursService,
 };
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Phpolar\Model\Model;
 use Phpolar\PurePhp\HtmlSafeContext;
 use Phpolar\PurePhp\TemplateEngine;
@@ -31,9 +32,9 @@ final class EmailReportForMonth extends AbstractTenantBasedRequestProcessor
         private readonly RemarksForMonthService $remarksService,
         private readonly CreditHoursService $creditHoursService,
         private readonly TemplateEngine $templateEngine,
-        readonly string $hashingKey,
+        readonly Hasher $hasher,
     ) {
-        parent::__construct(hashingKey: $hashingKey);
+        parent::__construct($hasher);
     }
 
     public function process(

--- a/src/Http/RequestProcessors/GetTimeEntries.php
+++ b/src/Http/RequestProcessors/GetTimeEntries.php
@@ -16,6 +16,7 @@ use Phpolar\{
 use EricFortmeyer\ActivityLog\{RemarksForMonth, MonthFilters, CreditHours, TimeEntry};
 use EricFortmeyer\ActivityLog\Services\{RemarksForMonthService, CreditHoursService, TimeEntryService};
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\{TimeEntriesContext, BadRequestContext};
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 
 /**
  * Class GetTimeEntries
@@ -29,9 +30,9 @@ final class GetTimeEntries extends AbstractTenantBasedRequestProcessor
         private readonly RemarksForMonthService $remarksForMonthService,
         private readonly CreditHoursService $creditHoursService,
         private readonly TemplateEngine $templateEngine,
-        readonly string $hashingKey = "",
+        readonly Hasher $hasher,
     ) {
-        parent::__construct(hashingKey: $hashingKey);
+        parent::__construct($hasher);
     }
 
     /**

--- a/src/Http/RequestProcessors/SaveCreditHours.php
+++ b/src/Http/RequestProcessors/SaveCreditHours.php
@@ -21,6 +21,7 @@ use EricFortmeyer\ActivityLog\Services\{
     TimeEntryService
 };
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\TimeEntriesContext;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 
 final class SaveCreditHours extends AbstractTenantBasedRequestProcessor
 {
@@ -29,9 +30,9 @@ final class SaveCreditHours extends AbstractTenantBasedRequestProcessor
         private readonly RemarksForMonthService $remarksService,
         private readonly TimeEntryService $timeEntryService,
         private readonly TemplateEngine $templateEngine,
-        readonly string $hashingKey = "",
+        readonly Hasher $hasher,
     ) {
-        parent::__construct(hashingKey: $hashingKey);
+        parent::__construct($hasher);
     }
 
     #[Authorize]

--- a/src/Http/RequestProcessors/SaveRemarksForMonth.php
+++ b/src/Http/RequestProcessors/SaveRemarksForMonth.php
@@ -21,6 +21,7 @@ use EricFortmeyer\ActivityLog\Services\{
     TimeEntryService
 };
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\TimeEntriesContext;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 
 final class SaveRemarksForMonth extends AbstractTenantBasedRequestProcessor
 {
@@ -29,9 +30,9 @@ final class SaveRemarksForMonth extends AbstractTenantBasedRequestProcessor
         private readonly CreditHoursService $creditHoursService,
         private readonly TimeEntryService $timeEntryService,
         private readonly TemplateEngine $templateEngine,
-        readonly string $hashingKey = "",
+        readonly Hasher $hasher,
     ) {
-        parent::__construct(hashingKey: $hashingKey);
+        parent::__construct($hasher);
     }
 
     #[Authorize]

--- a/src/Http/RequestProcessors/SubmitTimeEntry.php
+++ b/src/Http/RequestProcessors/SubmitTimeEntry.php
@@ -20,6 +20,7 @@ use EricFortmeyer\ActivityLog\{
     RemarksForMonth
 };
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\TimeEntriesContext;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Phpolar\Phpolar\Auth\Authorize;
 
 final class SubmitTimeEntry extends AbstractTenantBasedRequestProcessor
@@ -28,9 +29,9 @@ final class SubmitTimeEntry extends AbstractTenantBasedRequestProcessor
         private readonly TimeEntryService $timeEntryService,
         private readonly RemarksForMonthService $remarksForMonthService,
         private readonly TemplateEngine $templateEngine,
-        readonly string $hashingKey = "",
+        readonly Hasher $hasher,
     ) {
-        parent::__construct(hashingKey: $hashingKey);
+        parent::__construct(hasher: $hasher);
     }
 
     #[Authorize]

--- a/src/Utils/Hasher.php
+++ b/src/Utils/Hasher.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EricFortmeyer\ActivityLog\Utils;
+
+use SensitiveParameter;
+
+use function sodium_bin2hex;
+use function sodium_crypto_generichash;
+
+use const SODIUM_CRYPTO_GENERICHASH_BYTES_MIN;
+
+readonly class Hasher
+{
+    public function __construct(
+        #[SensitiveParameter]
+        private string $hashingKey,
+    ) {}
+
+    public function hash(
+        string $value
+    ): string {
+        return sodium_bin2hex(
+            $this->hashingKey !== ""
+                ?
+                sodium_crypto_generichash(
+                    message: $value,
+                    key: $this->hashingKey,
+                    length: SODIUM_CRYPTO_GENERICHASH_BYTES_MIN,
+                ) :
+                sodium_crypto_generichash(
+                    message: $value,
+                    length: SODIUM_CRYPTO_GENERICHASH_BYTES_MIN,
+                )
+        );
+    }
+}

--- a/src/config/dependencies/conf.d/request-processors.php
+++ b/src/config/dependencies/conf.d/request-processors.php
@@ -9,10 +9,9 @@ use EricFortmeyer\ActivityLog\Services\CreditHoursService;
 use EricFortmeyer\ActivityLog\Services\DataExportService;
 use EricFortmeyer\ActivityLog\Services\RemarksForMonthService;
 use EricFortmeyer\ActivityLog\Services\TimeEntryService;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Psr\Container\ContainerInterface;
 use Phpolar\PurePhp\TemplateEngine;
-
-use const EricFortmeyer\ActivityLog\config\DiTokens\HASH_KEY;
 
 return [
     GetTimeEntries::class => static fn(ContainerInterface $container) => new GetTimeEntries(
@@ -20,7 +19,7 @@ return [
         remarksForMonthService: $container->get(RemarksForMonthService::class),
         creditHoursService: $container->get(CreditHoursService::class),
         templateEngine: $container->get(TemplateEngine::class),
-        hashingKey: $container->get(HASH_KEY),
+        hasher: $container->get(Hasher::class),
     ),
 
     GetTimeEntry::class => static fn(ContainerInterface $container) => new GetTimeEntry(
@@ -32,28 +31,28 @@ return [
         $container->get(TimeEntryService::class),
         $container->get(RemarksForMonthService::class),
         $container->get(TemplateEngine::class),
-        hashingKey: $container->get(HASH_KEY),
+        hasher: $container->get(Hasher::class),
     ),
 
     SubmitTimeEntry::class => static fn(ContainerInterface $container) => new SubmitTimeEntry(
         $container->get(TimeEntryService::class),
         $container->get(RemarksForMonthService::class),
         $container->get(TemplateEngine::class),
-        hashingKey: $container->get(HASH_KEY),
+        hasher: $container->get(Hasher::class),
     ),
     SaveRemarksForMonth::class => static fn(ContainerInterface $container) => new SaveRemarksForMonth(
         creditHoursService: $container->get(CreditHoursService::class),
         remarksService: $container->get(RemarksForMonthService::class),
         timeEntryService: $container->get(TimeEntryService::class),
         templateEngine: $container->get(TemplateEngine::class),
-        hashingKey: $container->get(HASH_KEY),
+        hasher: $container->get(Hasher::class),
     ),
     SaveCreditHours::class => static fn(ContainerInterface $container) => new SaveCreditHours(
         creditHoursService: $container->get(CreditHoursService::class),
         remarksService: $container->get(RemarksForMonthService::class),
         timeEntryService: $container->get(TimeEntryService::class),
         templateEngine: $container->get(TemplateEngine::class),
-        hashingKey: $container->get(HASH_KEY),
+        hasher: $container->get(Hasher::class),
     ),
     DownloadDataExport::class => static fn(ContainerInterface $container) => new DownloadDataExport(
         $container->get(DataExportService::class),
@@ -64,6 +63,6 @@ return [
         remarksService: $container->get(RemarksForMonthService::class),
         creditHoursService: $container->get(CreditHoursService::class),
         templateEngine: $container->get(TemplateEngine::class),
-        hashingKey: $container->get(HASH_KEY),
+        hasher: $container->get(Hasher::class),
     )
 ];

--- a/src/config/dependencies/conf.d/utils.php
+++ b/src/config/dependencies/conf.d/utils.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EricFortmeyer\ActivityLog\Utils;
+
+use Psr\Container\ContainerInterface;
+
+use const EricFortmeyer\ActivityLog\config\DiTokens\HASH_KEY;
+
+return [
+    Hasher::class => static fn(ContainerInterface $container) => new Hasher(
+        hashingKey: $container->get(HASH_KEY)
+    )
+];

--- a/tests/unit/Http/RequestProcessors/AbstractTenantBasedRequestProcessorTest.php
+++ b/tests/unit/Http/RequestProcessors/AbstractTenantBasedRequestProcessorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EricFortmeyer\ActivityLog\UnitTests\Http\RequestProcessors;
 
 use EricFortmeyer\ActivityLog\Http\RequestProcessors\AbstractTenantBasedRequestProcessor;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Phpolar\Phpolar\Auth\User;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -29,13 +30,18 @@ final class AbstractTenantBasedRequestProcessorTest extends TestCase
     }
 
     #[Test]
-    #[TestDox("Shall compute (\$rawHashingKey) as the expected tenant id (\$computedTenantId)")]
-    #[TestWith(["hashhashhashhash", "c9b1304638e067d3957a7921f3f75dec"])]
-    #[TestWith(["hashhashhashhash", "c9b1304638e067d3957a7921f3f75dec"])]
-    #[TestWith(["", "c4b3726644bc9313463e951cc83abf6a"])]
-    public function ewoijf(string $rawHashingKey, string $computedTenantId)
+    #[TestDox("Shall compute the expected tenant id (\$computedTenantId)")]
+    #[TestWith(["c9b1304638e067d3957a7921f3f75dec"])]
+    #[TestWith(["c4b3726644bc9313463e951cc83abf6a"])]
+    public function ewoijf(string $computedTenantId)
     {
-        $requestProcessor = new class ($rawHashingKey) extends AbstractTenantBasedRequestProcessor {
+        $hasherMock = $this->createMock(Hasher::class);
+        $hasherMock->expects($this->once())
+            ->method("hash")
+            ->with(self::$user->nickname)
+            ->willReturn($computedTenantId);
+
+        $requestProcessor = new class ($hasherMock) extends AbstractTenantBasedRequestProcessor {
             public function process(): array|bool|int|null|object|string
             {
                 throw new \Exception('Not implemented');

--- a/tests/unit/Http/RequestProcessors/DeleteTimeEntryTest.php
+++ b/tests/unit/Http/RequestProcessors/DeleteTimeEntryTest.php
@@ -11,6 +11,7 @@ use EricFortmeyer\ActivityLog\Services\TimeEntryService;
 use EricFortmeyer\ActivityLog\TimeEntry;
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\NotFoundContext;
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\TimeEntriesContext;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Phpolar\Phpolar\Auth\User;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -38,6 +39,7 @@ final class DeleteTimeEntryTest extends TestCase
 
     protected function setUp(): void
     {
+        $hasher = $this->createStub(Hasher::class);
         $this->timeEntryService = $this->createMock(TimeEntryService::class);
         $this->remarksForMonthService = $this->createMock(RemarksForMonthService::class);
         $this->remarksForMonthService
@@ -48,6 +50,7 @@ final class DeleteTimeEntryTest extends TestCase
             timeEntryService: $this->timeEntryService,
             remarksForMonthService: $this->remarksForMonthService,
             templateEngine: $this->templateEngine,
+            hasher: $hasher,
         );
         $this->deleteTimeEntry->user = new User(
             name: "",

--- a/tests/unit/Http/RequestProcessors/GetTimeEntriesTest.php
+++ b/tests/unit/Http/RequestProcessors/GetTimeEntriesTest.php
@@ -12,6 +12,7 @@ use EricFortmeyer\ActivityLog\Services\RemarksForMonthService;
 use EricFortmeyer\ActivityLog\Services\TimeEntryService;
 use EricFortmeyer\ActivityLog\TimeEntry;
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\TimeEntriesContext;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Phpolar\Phpolar\Auth\User;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,6 +36,7 @@ final class GetTimeEntriesTest extends TestCase
 
     protected function setUp(): void
     {
+        $hasher = $this->createStub(Hasher::class);
         $this->timeEntryService = $this->createMock(TimeEntryService::class);
         $this->remarksForMonthService = $this->createMock(RemarksForMonthService::class);
         $this->creditHoursService = $this->createMock(CreditHoursService::class);
@@ -44,6 +46,7 @@ final class GetTimeEntriesTest extends TestCase
             remarksForMonthService: $this->remarksForMonthService,
             creditHoursService: $this->creditHoursService,
             templateEngine: $this->templateEngine,
+            hasher: $hasher,
         );
         $this->getTimeEntries->user = new User(
             name: "",

--- a/tests/unit/Http/RequestProcessors/SubmitTimeEntryTest.php
+++ b/tests/unit/Http/RequestProcessors/SubmitTimeEntryTest.php
@@ -12,6 +12,7 @@ use EricFortmeyer\ActivityLog\TimeEntry;
 use EricFortmeyer\ActivityLog\UnitTests\DataProviders\TimeEntryDataProvider;
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\TimeEntriesContext;
 use EricFortmeyer\ActivityLog\UserInterface\Contexts\TimeEntryContext;
+use EricFortmeyer\ActivityLog\Utils\Hasher;
 use Phpolar\Phpolar\Auth\User;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,6 +36,7 @@ final class SubmitTimeEntryTest extends TestCase
 
     protected function setUp(): void
     {
+        $hasher = $this->createStub(Hasher::class);
         $this->timeEntryService = $this->createMock(TimeEntryService::class);
         $this->remarksForMonthService = $this->createMock(RemarksForMonthService::class);
         $this->remarksForMonthService
@@ -45,6 +47,7 @@ final class SubmitTimeEntryTest extends TestCase
             timeEntryService: $this->timeEntryService,
             remarksForMonthService: $this->remarksForMonthService,
             templateEngine: $this->templateEngine,
+            hasher: $hasher,
         );
         $this->submitTimeEntry->user = new User(
             name: "FAKE_NAME",

--- a/tests/unit/Utils/HasherTest.php
+++ b/tests/unit/Utils/HasherTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EricFortmeyer\ActivityLog\Utils;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\TestWith;
+
+#[CoversClass(Hasher::class)]
+final class HasherTest extends TestCase
+{
+    #[Test]
+    #[TestDox("Shall compute \$input as the \$expectedOutput using \$hashingKey")]
+    #[TestWith(["hashhashhashhash", "FAKE_NICKNAME", "c9b1304638e067d3957a7921f3f75dec"])]
+    #[TestWith(["", "FAKE_NICKNAME", "c4b3726644bc9313463e951cc83abf6a"])]
+    public function dfsjio(
+        string $hashingKey,
+        string $input,
+        string $expectedOutput,
+    ) {
+        $hasher = new Hasher(
+            hashingKey: $hashingKey
+        );
+
+        $result = $hasher->hash($input);
+
+        $this->assertSame($expectedOutput, $result);
+    }
+}


### PR DESCRIPTION
Improves testability and allows testing request processors on CI runners that do not include modules the implementation depends on (Sodium).