### PR TITLE
fix: clear time entry form after deleting a time entry

### DIFF
--- a/src/Http/RequestProcessors/DeleteTimeEntry.php
+++ b/src/Http/RequestProcessors/DeleteTimeEntry.php
@@ -45,10 +45,12 @@ final class DeleteTimeEntry extends AbstractTenantBasedRequestProcessor
             );
         }
 
+        $newEntryForForm = new TimeEntry();
+
 
         $month = $monthFilters->getMonth();
         $year = $monthFilters->getYear();
-        TimeEntry::setUninitializedValues(timeEntry: $deletedEntry, month: $month, year: $year);
+        TimeEntry::setUninitializedValues(timeEntry: $newEntryForForm, month: $month, year: $year);
 
         $timeEntries = $this->timeEntryService->getAllByMonth(
             month: $month,
@@ -68,7 +70,7 @@ final class DeleteTimeEntry extends AbstractTenantBasedRequestProcessor
                     appVersion: $this->appVersion,
                     timeEntries: $timeEntries,
                     tenantId: $this->getTenantId(),
-                    currentEntry: $deletedEntry,
+                    currentEntry: $newEntryForForm,
                     filters: $monthFilters,
                     user: $this->user
                 )
@@ -76,7 +78,7 @@ final class DeleteTimeEntry extends AbstractTenantBasedRequestProcessor
                     appVersion: $this->appVersion,
                     timeEntries: $timeEntries,
                     tenantId: $this->getTenantId(),
-                    currentEntry: $deletedEntry,
+                    currentEntry: $newEntryForForm,
                     filters: $monthFilters,
                     remarks: $remarks,
                     user: $this->user

--- a/src/templates/index.phtml
+++ b/src/templates/index.phtml
@@ -146,7 +146,6 @@ use function EricFortmeyer\ActivityLog\UserInterface\HTMLElements\head;
                             )
                             ?>
                         </div>
-                        <input type="hidden" id="filterYear" name="filterYear" value="<?= $view->getYearFilter() ?>" />
                         <?php foreach ($view->currentEntry as $field => $value): ?>
                             <?php $inputType = $view->currentEntry->getInputType($field); ?>
                             <?php if ($inputType === InputTypes::Hidden): ?>

--- a/tests/unit/Http/RequestProcessors/DeleteTimeEntryTest.php
+++ b/tests/unit/Http/RequestProcessors/DeleteTimeEntryTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Phpolar\PurePhp\TemplateEngine;
 use Phpolar\Storage\NotFound;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Stub;
 
 #[CoversClass(DeleteTimeEntry::class)]
@@ -54,13 +56,16 @@ final class DeleteTimeEntryTest extends TestCase
         );
     }
 
-    public function testProcessDeletesTimeEntry(): void
+    #[Test]
+    #[TestDox("Shall delete a time entry")]
+    public function deletes(): void
     {
         $entryId = "12345";
         $deletedEntry = new TimeEntry();
         $deletedEntry->id = $entryId;
         $deletedEntry->dayOfMonth = 1;
         $deletedEntry->year = "2025";
+        $deletedEntry->month = 10;
         $deletedEntry->hours = 8;
         $deletedEntry->minutes = 30;
         $deletedEntry->createdOn = new \DateTimeImmutable();
@@ -75,7 +80,9 @@ final class DeleteTimeEntryTest extends TestCase
         $this->assertStringContainsString("Activity", $response);
     }
 
-    public function testProcessHandlesNotFound(): void
+    #[Test]
+    #[TestDox("Shall handle not found time entry")]
+    public function handlesNotFound(): void
     {
         $entryId = "nonexistent";
         $this->timeEntryService


### PR DESCRIPTION
The form was displaying the deleted time entry's values.

Signed-off-by: Eric Fortmeyer <e.fortmeyer01@gmail.com>